### PR TITLE
Update project.yaml with email of team member.

### DIFF
--- a/projects/icu/project.yaml
+++ b/projects/icu/project.yaml
@@ -4,6 +4,7 @@ auto_ccs:
  - andy.heninger@gmail.com
  - markus.icu@gmail.com
  - jefgen.msft@gmail.com
+ - shane@unicode.org
 sanitizers:
  - address
  - memory


### PR DESCRIPTION
Remove dictionaries from COPY statement.

Dictionary is no longer in the project/icu/ directory, was moved to the public ICU project as part of
PR https://github.com/unicode-org/icu/pull/321. 
